### PR TITLE
security: CWE-829: Pin third-party Docker images by digest — VC-53712

### DIFF
--- a/jenkins/venafi-csp-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-ant-signjar/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11'
+            image 'maven:3.8.1-adoptopenjdk-11@sha256:50f49da7cc26d76b30ba075b9c62a027333fccd2db395d81d812885b38e365b3'
             args '-u root'
         }
     }

--- a/jenkins/venafi-csp-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-ant-signjar/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'maven:3.8.1-adoptopenjdk-11@sha256:50f49da7cc26d76b30ba075b9c62a027333fccd2db395d81d812885b38e365b3'
+            args '-u root -v /root/.m2:/root/.m2'
         }
     }
     stages {

--- a/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'gradle:7.5.1-jdk11'
+            image 'gradle:7.5.1-jdk11@sha256:4d4b2edee1e26bab2a5f5be5052cd4f83d9252caa344981b28b9b6c7a756fd3b'
             args '-u root'
         }
     }

--- a/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'gradle:7.5.1-jdk11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'gradle:7.5.1-jdk11@sha256:4d4b2edee1e26bab2a5f5be5052cd4f83d9252caa344981b28b9b6c7a756fd3b'
+            args '-u root -v /root/.m2:/root/.m2'
         }
     }
     stages {

--- a/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
+++ b/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'maven:3.8.1-adoptopenjdk-11@sha256:50f49da7cc26d76b30ba075b9c62a027333fccd2db395d81d812885b38e365b3'
+            args '-u root -v /root/.m2:/root/.m2'
         }
     }
     stages {


### PR DESCRIPTION
## Summary

This PR addresses CWE-829 (Inclusion of Functionality from Untrusted Control Sphere) and CWE-494 (Download of Code Without Integrity Check) by pinning third-party Docker images to specific SHA256 digests in all Jenkinsfiles.

## Finding

Three Jenkinsfiles reference third-party Docker images from Docker Hub using mutable tags without digest pinning:
- `jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile`: `gradle:7.5.1-jdk11`
- `jenkins/venafi-csp-ant-signjar/Jenkinsfile`: `maven:3.8.1-adoptopenjdk-11`
- `jenkins/venafi-csp-maven-jarsigner/Jenkinsfile`: `maven:3.8.1-adoptopenjdk-11`

These mutable tag references allow any party who can push to Docker Hub to substitute arbitrary code that executes with the signing agent's privileges and credential access, presenting a CVSS 9.2 critical risk.

## Remediation

Updated all three Jenkinsfiles to pin the Docker images to their specific SHA256 digests:
- `gradle:7.5.1-jdk11@sha256:4d4b2edee1e26bab2a5f5be5052cd4f83d9252caa344981b28b9b6c7a756fd3b`
- `maven:3.8.1-adoptopenjdk-11@sha256:50f49da7cc26d76b30ba075b9c62a027333fccd2db395d81d812885b38e365b3`

This ensures that the exact same image content is used for each build, preventing supply chain attacks via image substitution.

## Verification

- All three Jenkinsfiles updated with digest-pinned image references
- No functional changes to the build processes
- Digests verified against Docker Hub registry at time of fix

**Files changed:**
- `jenkins/venafi-csp-ant-signjar/Jenkinsfile`
- `jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile`
- `jenkins/venafi-csp-maven-jarsigner/Jenkinsfile`