### PR TITLE
security: CWE-829: Pin container images to digests — VC-53711

### DIFF
--- a/argocd/venafi-csp-jarsigner.yml
+++ b/argocd/venafi-csp-jarsigner.yml
@@ -21,8 +21,8 @@ spec:
           - name: my-test-jar
             from: "{{steps.generate-artifact.outputs.artifacts.my-jar}}"
   - name: buildjar
-    container: 
-      image: atlassian/default-image:3
+    container:
+      image: atlassian/default-image:3@sha256:496b5b602817d68ea0d0b6a030708cd1017f7cb28d69b74f22dfe26229199f91
       command: [sh, -c]
       args: ["wget https://myrepo/test.jar -O /root/test.jar"]
     outputs:
@@ -51,7 +51,7 @@ spec:
           value: Sample-Development-Environment
         - name: INPUT_PATH
           value: /root/test.jar
-      image: zosocanuck/venafi-csp-ubuntu:latest
+      image: zosocanuck/venafi-csp-ubuntu:latest@sha256:6056b44e34b1ddc29f2ed492ae30d7d8583090e7ceef448518b65e1def6173e3
       command: [bash]
       source: |
         apt-get update

--- a/bitbucket/venafi-csp-jarsigner.yml
+++ b/bitbucket/venafi-csp-jarsigner.yml
@@ -2,7 +2,7 @@
 # for Java applications using Venafi CodeSign Protect
 # Ensure the necessary Pipeline Repository Variables are set based on this example
 
-image: zosocanuck/venafi-csp-ubuntu:latest
+image: zosocanuck/venafi-csp-ubuntu:latest@sha256:6056b44e34b1ddc29f2ed492ae30d7d8583090e7ceef448518b65e1def6173e3
 
 pipelines:
   default:

--- a/gitlab/venafi-csp-cosign.yml
+++ b/gitlab/venafi-csp-cosign.yml
@@ -3,7 +3,7 @@ stages:
 
 sign_image_linux:
   stage: docker
-  image: docker.io/venafi/code-signing:latest-linux
+  image: docker.io/venafi/code-signing:latest-linux@sha256:09dccbaf1940e846f41b72af5c9596827d8d8779aa67307d11182c50467d0b1f
   tags:
     - linux
   script:

--- a/gitlab/venafi-csp-signtool.yml
+++ b/gitlab/venafi-csp-signtool.yml
@@ -3,7 +3,7 @@ stages:
 
 sign_windows:
   stage: sign
-  image: docker.io/venafi/code-signing:latest-windows
+  image: docker.io/venafi/code-signing:latest-windows@sha256:f1df4b3a1132c3de0ca9df68fd697cd6f6bea2f0ca31d8ca164f5a75296334ae
   tags:
     - windows
   script:

--- a/jenkins/venafi-csp-ant-signjar/Dockerfile
+++ b/jenkins/venafi-csp-ant-signjar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.5@sha256:f7d2b5725685826823bc6b154c0de02832e5e6daf7dc25a00ab00f1158fabfc8
 
 #Create Ant Dir
 RUN mkdir -p /opt/ant/


### PR DESCRIPTION
## Summary

This PR remediates CWE-829 (Inclusion of Functionality from Untrusted Control Sphere) by pinning all mutable container image references to immutable SHA256 digests across all pipeline examples.

## Finding

**CVSS:** 9.2 (CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N)

Multiple pipeline examples referenced container images using mutable tags (`:latest`, `:stable`, version tags without digests), allowing attackers who can push to the image registry to substitute malicious image content that executes with full build-agent privileges and code-signing access.

Vulnerable patterns found:
- `atlassian/default-image:3`
- `zosocanuck/venafi-csp-ubuntu:latest`
- `docker.io/venafi/code-signing:latest-windows`
- `docker.io/venafi/code-signing:latest-linux`
- `alpine:3.5`

## Remediation

All container image references have been pinned to their current SHA256 digests using the format `image:tag@sha256:<digest>`:

1. **argocd/venafi-csp-jarsigner.yml** - Pinned 2 images
2. **bitbucket/venafi-csp-jarsigner.yml** - Pinned 1 image
3. **gitlab/venafi-csp-signtool.yml** - Pinned 1 image
4. **gitlab/venafi-csp-cosign.yml** - Pinned 1 image
5. **jenkins/venafi-csp-ant-signjar/Dockerfile** - Pinned 1 image

The digests were obtained via `docker manifest inspect` to ensure they reference the current legitimate image content.

## Verification

- **Files changed:** 5 files, 7 insertions(+), 7 deletions(-)
- **Build status:** N/A (example repository)
- **Tests status:** N/A (example repository)

All image references now use immutable digest pins, preventing registry-based supply chain attacks.