### PR TITLE
security: CWE-668: Remove insecure ~/.m2 bind-mount — VC-53708

### DIFF
--- a/jenkins/venafi-csp-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-ant-signjar/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'maven:3.8.1-adoptopenjdk-11'
+            args '-u root'
         }
     }
     stages {

--- a/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'gradle:7.5.1-jdk11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'gradle:7.5.1-jdk11'
+            args '-u root'
         }
     }
     stages {

--- a/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
+++ b/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'maven:3.8.1-adoptopenjdk-11' 
-            args '-u root -v /root/.m2:/root/.m2' 
+            image 'maven:3.8.1-adoptopenjdk-11'
+            args '-u root'
         }
     }
     stages {

--- a/jenkins/venafi-csp-maven-jarsigner/jenkins/Jenkinsfile
+++ b/jenkins/venafi-csp-maven-jarsigner/jenkins/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent {
         docker {
             image 'maven:3-alpine'
-            args '-v /root/.m2:/root/.m2'
         }
     }
     stages {


### PR DESCRIPTION
## Summary

Removes insecure bind-mount of the host's `~/.m2` directory in Jenkins Docker pipeline examples to prevent exposure of Maven credentials and secrets to containerized build processes.

## Finding

**CWE-668 (Exposure of Resource to Wrong Sphere) / CWE-732 (Incorrect Permission Assignment for Critical Resource)**  
CVSS: 5.7 (CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:L/VA:N/SC:N/SI:N/SA:N)

Four Jenkins pipeline examples bind-mounted the entire `~/.m2` directory from the host into Docker build containers with full read-write access:

```groovy
args '-v /root/.m2:/root/.m2'
```

This exposes sensitive files in the host's Maven directory to any code executing in the container:
- `~/.m2/settings.xml` — typically contains credentials for artifact repositories (Nexus, Artifactory)
- `~/.m2/settings-security.xml` — master password file for encrypted credentials
- Local repository cache — potential attack surface for dependency poisoning

If the build process is compromised via malicious dependencies, supply chain attacks, or compromised transitive dependencies, attackers gain read access to these credential files.

## Remediation

Removed the `-v /root/.m2:/root/.m2` bind-mount from all four affected Jenkinsfiles:
- `jenkins/venafi-csp-maven-jarsigner/Jenkinsfile`
- `jenkins/venafi-csp-maven-jarsigner/jenkins/Jenkinsfile`
- `jenkins/venafi-csp-ant-signjar/Jenkinsfile`
- `jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile`

Build containers now use their own isolated Maven local repository within the container filesystem. Maven will download dependencies as needed during each build. For production use, teams should:
- Use Jenkins credentials binding to inject repository credentials as environment variables
- Create CI-specific Maven settings files with minimal credential scope
- If caching is required for performance, mount only the local repository directory (not settings files)

## Verification

- ✅ Removed all instances of `~/.m2` bind-mounts from Jenkins pipeline configurations
- ✅ Build containers no longer have access to host Maven credential files
- ✅ Pipeline examples remain functional with container-isolated Maven repositories