### PR TITLE
security: CWE-494: Download of Code Without Integrity Check — VC-53705

### DIFF
--- a/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
@@ -18,10 +18,10 @@ pipeline {
                    '''
             }
         }
-        stage('Build') { 
+        stage('Build') {
             steps {
-                sh 'gradle build'
-                sh 'gradle sign' 
+                sh './gradlew build'
+                sh './gradlew sign'
             }
         }
     }

--- a/jenkins/venafi-csp-gradle-ant-signjar/gradle/wrapper/gradle-wrapper.properties
+++ b/jenkins/venafi-csp-gradle-ant-signjar/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionSha256Sum=9dc729f6dbfbbc4df1692665d301e028976dacac296a126f16148941a9cf012e


### PR DESCRIPTION
## Summary

This PR remediates CWE-494 (Download of Code Without Integrity Check) in the Gradle-based Jenkins pipeline example by adding SHA256 verification to the Gradle wrapper and updating the Jenkinsfile to use the verified wrapper instead of the system gradle binary.

## Finding

**CVSS:** 5.4 (CVSS:4.0/AV:N/AC:H/AT:P/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:H/SA:N) — CONDITIONAL

**CWE ID:** CWE-494 (Download of Code Without Integrity Check)

**Impact:** The `jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile` pipeline used the system `gradle` binary rather than a pinned, SHA-verified Gradle wrapper. This created a dependency on an uncontrolled, unverified external artifact. Any modification to the agent-installed gradle binary or plugin configuration could influence the build and subsequent signing step.

## Remediation

Applied minimal, focused changes to address the vulnerability:

1. **Added SHA256 verification** to `gradle/wrapper/gradle-wrapper.properties`:
   - Added `distributionSha256Sum=9dc729f6dbfbbc4df1692665d301e028976dacac296a126f16148941a9cf012e`
   - This ensures the Gradle 5.2.1 distribution is verified against the official checksum

2. **Updated Jenkinsfile** to use the verified wrapper:
   - Changed `sh 'gradle build'` to `sh './gradlew build'`
   - Changed `sh 'gradle sign'` to `sh './gradlew sign'`
   - This ensures the pipeline uses the SHA-verified Gradle wrapper instead of an unverified system binary

## Verification

- Modified 2 files: `Jenkinsfile` and `gradle/wrapper/gradle-wrapper.properties`
- Changes are minimal and focused on the security issue
- The Gradle wrapper (`gradlew`, `gradlew.bat`, `gradle-wrapper.jar`) was already committed to the repository
- SHA256 checksum sourced from official Gradle distribution: https://services.gradle.org/distributions/gradle-5.2.1-all.zip.sha256