### PR TITLE
security: CWE-295: Remove blind certificate trust — VC-53702

### DIFF
--- a/argocd/venafi-csp-jarsigner.yml
+++ b/argocd/venafi-csp-jarsigner.yml
@@ -53,15 +53,23 @@ spec:
           value: /root/test.jar
       image: zosocanuck/venafi-csp-ubuntu:latest
       command: [bash]
+      volumeMounts:
+        - name: tpp-ca-cert
+          mountPath: /etc/venafi
+          readOnly: true
       source: |
         apt-get update
         apt-get install --no-install-recommends -y openjdk-8-jdk-headless
         wget --user=poc --password=Passw0rd123! https://myrepo/venafipkcs11.txt -O /root/venafipkcs11.conf
         wget --user=poc --password=Passw0rd123! https://myrepo/poc_guide/test.jar -O /root/test.jar
         echo "Configure Venafi CSP client"
-        pkcs11config trust -hsmurl $TPP_HSM_URL -force
+        pkcs11config trust --file /etc/venafi/ca.pem
         pkcs11config seturl -authurl $TPP_AUTH_URL -hsmurl $TPP_HSM_URL
         pkcs11config getgrant --authurl=$TPP_AUTH_URL --hsmurl=$TPP_HSM_URL --username=$TPP_USERNAME --password=$TPP_PASSWORD --force
         echo "Sign and Verify Using JarSigner"
         jarsigner $INPUT_PATH $CERTIFICATE_LABEL -storepass bogus -storetype PKCS11 -keystore NONE -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf
         jarsigner -verify -keystore NONE -storetype PKCS11 -storepass bogus -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf $INPUT_PATH
+    volumes:
+      - name: tpp-ca-cert
+        secret:
+          secretName: tpp-ca-cert

--- a/bitbucket/venafi-csp-jarsigner.yml
+++ b/bitbucket/venafi-csp-jarsigner.yml
@@ -14,7 +14,8 @@ pipelines:
           - apt-get install --no-install-recommends -y openjdk-8-jdk-headless
           - wget https://myrepo/venafipkcs11.txt -O /root/venafipkcs11.conf
           - wget https://myrepo/test.jar -O /root/test.jar
-          - /opt/venafi/codesign/bin/pkcs11config trust -hsmurl $VENAFITPPURL/vedhsm -force
+          - echo "$TPP_CA_PEM" > /tmp/tpp-ca.pem
+          - /opt/venafi/codesign/bin/pkcs11config trust --file /tmp/tpp-ca.pem
           - /opt/venafi/codesign/bin/pkcs11config seturl -authurl $VENAFITPPURL/vedauth -hsmurl $VENAFITPPURL/vedhsm
           - /opt/venafi/codesign/bin/pkcs11config getgrant --authurl=$VENAFITPPURL/vedauth --hsmurl=$VENAFITPPURL/vedhsm --username=$CSPUSER --password=$CSPPASSWORD --force
           - echo "Sign and Verify Using JarSigner"


### PR DESCRIPTION
## Summary

Fixes CWE-295 (Improper Certificate Validation) by replacing blind TOFU trust operations with proper CA certificate validation in ArgoCD and Bitbucket pipeline examples.

## Finding

**CWE-295: Improper Certificate Validation**
CVSS: 8.2 (High)

The `pkcs11config trust -hsmurl <url> -force` command was invoked at the start of every ephemeral job run in:
- `argocd/venafi-csp-jarsigner.yml:62`
- `bitbucket/venafi-csp-jarsigner.yml:17`

The `-force` flag suppresses the fingerprint-confirmation prompt, causing the pipeline to blindly trust whatever certificate the HSM URL endpoint presents. Because builds run in ephemeral containers, this blind trust occurs on every single build. A MITM or DNS-spoofing attacker can have their certificate trusted silently, receiving the cleartext TPP password from the subsequent `getgrant` command.

## Remediation

**ArgoCD pipeline:**
- Replaced `pkcs11config trust -hsmurl $TPP_HSM_URL -force` with `pkcs11config trust --file /etc/venafi/ca.pem`
- Added volume mount for Kubernetes Secret `tpp-ca-cert` containing the TPP issuing CA certificate
- The CA certificate is now explicitly validated instead of blindly trusting any presented certificate

**Bitbucket pipeline:**
- Replaced `pkcs11config trust -hsmurl $VENAFITPPURL/vedhsm -force` with certificate file-based trust
- Added step to write the `$TPP_CA_PEM` secured variable to `/tmp/tpp-ca.pem`
- Changed to `pkcs11config trust --file /tmp/tpp-ca.pem`

**Note for adopters:**
- **ArgoCD users** must create Kubernetes Secret `tpp-ca-cert` with key `ca.pem` containing the TPP issuing CA certificate
- **Bitbucket users** must configure the secured variable `TPP_CA_PEM` containing the TPP issuing CA certificate in PEM format

## Verification

- Static verification: No instances of `trust.*-force` remain in the codebase
- The remediation ensures certificates are validated against the known CA instead of accepting arbitrary certificates
- MITM attacks presenting self-signed certificates will now be rejected as they won't chain to the pinned CA certificate