### PR TITLE
security: CWE-532: Suppress password echo in CI logs — VC-53707

### DIFF
--- a/argocd/venafi-csp-jarsigner.yml
+++ b/argocd/venafi-csp-jarsigner.yml
@@ -61,7 +61,9 @@ spec:
         echo "Configure Venafi CSP client"
         pkcs11config trust -hsmurl $TPP_HSM_URL -force
         pkcs11config seturl -authurl $TPP_AUTH_URL -hsmurl $TPP_HSM_URL
+        set +x
         pkcs11config getgrant --authurl=$TPP_AUTH_URL --hsmurl=$TPP_HSM_URL --username=$TPP_USERNAME --password=$TPP_PASSWORD --force
+        set -x
         echo "Sign and Verify Using JarSigner"
         jarsigner $INPUT_PATH $CERTIFICATE_LABEL -storepass bogus -storetype PKCS11 -keystore NONE -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf
         jarsigner -verify -keystore NONE -storetype PKCS11 -storepass bogus -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf $INPUT_PATH

--- a/awscodebuild/venafi-csp-cosign-buildspec.yml
+++ b/awscodebuild/venafi-csp-cosign-buildspec.yml
@@ -27,5 +27,7 @@ phases:
       - echo Pushing the Docker image...
       - docker push docker.io/myorg/$IMAGE_REPO_NAME:$IMAGE_TAG
       - echo CSP authentication
+      - set +x
       - /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=https://$TPP_URL/vedauth --hsmurl=https://$TPP_URL/vedhsm --username=$USERNAME --password=$PASSWORD
+      - set -x
       - cosign sign --key "pkcs11:slot-id=0;object=Container-Signing-Production?module-path=/opt/venafi/codesign/lib/venafipkcs11.so&pin-value=1234" docker.io/myorg/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/bitbucket/venafi-csp-jarsigner.yml
+++ b/bitbucket/venafi-csp-jarsigner.yml
@@ -16,7 +16,9 @@ pipelines:
           - wget https://myrepo/test.jar -O /root/test.jar
           - /opt/venafi/codesign/bin/pkcs11config trust -hsmurl $VENAFITPPURL/vedhsm -force
           - /opt/venafi/codesign/bin/pkcs11config seturl -authurl $VENAFITPPURL/vedauth -hsmurl $VENAFITPPURL/vedhsm
+          - set +x
           - /opt/venafi/codesign/bin/pkcs11config getgrant --authurl=$VENAFITPPURL/vedauth --hsmurl=$VENAFITPPURL/vedhsm --username=$CSPUSER --password=$CSPPASSWORD --force
+          - set -x
           - echo "Sign and Verify Using JarSigner"
           - jarsigner /root/test.jar Sample-Development-Environment -storepass bogus -storetype PKCS11 -keystore NONE -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf
           - jarsigner -verify -keystore NONE -storetype PKCS11 -storepass bogus -providerclass sun.security.pkcs11.SunPKCS11 -providerArg /root/venafipkcs11.conf /root/test.jar

--- a/bitbucket/venafi-csp-signtool.yml
+++ b/bitbucket/venafi-csp-signtool.yml
@@ -15,7 +15,9 @@ pipelines:
           - 'windows'
         script:
           - |
+            set +x
             cspconfig getgrant --authurl=$TPP_URL/vedauth --hsmurl=$TPP_URL/vedhsm --username=$TPP_USERNAME --password=$TPP_PASSWORD --force
+            set -x
             cspconfig sync
             cspconfig list
             signtool sign /v /fd sha256 /n signer.example.com /td sha256 /tr http://timestamp.digicert.com c:\temp\sample.exe

--- a/gitlab/venafi-csp-apple-codesign.yml
+++ b/gitlab/venafi-csp-apple-codesign.yml
@@ -6,7 +6,9 @@ stages:          # List of stages for jobs, and their order of execution
 build-job:  # Build and Sign
   stage: build_sign
   script:
+    - set +x
     - tkdriverconfig getgrant --hsmurl=${TPP_URL}/vedhsm --authurl=${TPP_URL}/vedauth --username=${TPP_USERNAME} --password=${TPP_PASSWORD}
+    - set -x
     - xcodebuild clean -project SampleIOSApp.xcodeproj -scheme SampleIOSApp archive -configuration Release -archivePath archives/
   artifacts:
     paths:

--- a/jenkins/venafi-csp-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-ant-signjar/Jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
                        wget https://$CSP_DOMAIN/csc/clients/venafi-csc-latest-x86_64.deb
                        wget https://$CSP_DOMAIN/poc_guide/venafipkcs11.txt -O /root/venafipkcs11.txt
                        dpkg -i venafi-csc-latest-x86_64.deb
+                       set +x
                        /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$CSP_USER --password=$CSP_PASSWORD
+                       set -x
                    '''
             }
         }

--- a/jenkins/venafi-csp-apksigner.groovy
+++ b/jenkins/venafi-csp-apksigner.groovy
@@ -14,7 +14,7 @@ pipeline {
         stage("Venafi CodeSign Protect") {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'signer-cred', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    sh '/opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$USERNAME --password=$PASSWORD'
+                    sh 'set +x; /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$USERNAME --password=$PASSWORD; set -x'
                     sh 'wget https://my.repo.com/venafipkcs11.txt -O ~/venafipkcs11.txt'
                     sh 'apksigner sign --ks NONE --ks-pass "pass:test" --provider-class sun.security.pkcs11.SunPKCS11 --provider-arg ~/venafipkcs11.txt --ks-type PKCS11 --ks-key-alias my-production-cert ~/test.apk'
                 }

--- a/jenkins/venafi-csp-cosign.groovy
+++ b/jenkins/venafi-csp-cosign.groovy
@@ -15,7 +15,7 @@ pipeline {
         stage("Venafi") {
             steps {
                 withCredentials([usernamePassword(credentialsId: 'signer-cred', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                    sh '/opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$USERNAME --password=$PASSWORD'
+                    sh 'set +x; /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$USERNAME --password=$PASSWORD; set -x'
                     sh 'docker login ghcr.io -u myaccount -p $GITHUB_PAT'
                     sh 'cosign sign --key "pkcs11:slot-id=0;object=Production?module-path=/opt/venafi/codesign/lib/venafipkcs11.so&pin-value=1234" ghcr.io/myorg/sample-image@sha256:521311a0923441ac832704e7b9fe4daa0a04685a01c9cf54ff3382fd1cde9411'
                 }

--- a/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
+++ b/jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
                        wget https://$CSP_DOMAIN/csc/clients/venafi-csc-latest-x86_64.deb
                        wget https://$CSP_DOMAIN/poc_guide/venafipkcs11.txt -O /root/venafipkcs11.txt
                        dpkg -i venafi-csc-latest-x86_64.deb
+                       set +x
                        /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$CSP_USER --password=$CSP_PASSWORD
+                       set -x
                    '''
             }
         }

--- a/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
+++ b/jenkins/venafi-csp-maven-jarsigner/Jenkinsfile
@@ -14,7 +14,9 @@ pipeline {
                        wget https://$CSP_DOMAIN/csc/clients/venafi-csc-latest-x86_64.deb
                        wget https://$CSP_DOMAIN/poc_guide/venafipkcs11.txt -O /root/venafipkcs11.txt
                        dpkg -i venafi-csc-latest-x86_64.deb
+                       set +x
                        /opt/venafi/codesign/bin/pkcs11config getgrant --force --authurl=$CSP_AUTH_URL --hsmurl=$CSP_HSM_URL --username=$CSP_USER --password=$CSP_PASSWORD
+                       set -x
                    '''
             }
         }


### PR DESCRIPTION
## Summary

This PR remediates CWE-532 (Insertion of Sensitive Information into Log File) by adding `set +x` / `set -x` around commands that pass passwords via command-line arguments, preventing credential disclosure in CI job logs and process listings.

## Finding

**CWE-532: Insertion of Sensitive Information into Log File**
- CVSS: 7.1 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)

Multiple pipeline examples passed TPP passwords and API keys as command-line arguments to `pkcs11config getgrant`, `tkdriverconfig getgrant`, and `cspconfig getgrant`. Command-line arguments are visible in:
- Process listings (`ps`, `/proc/<pid>/cmdline`)
- Jenkins/GitLab/Bitbucket CI job logs (when command echoing is enabled)

Any user with access to job logs or the build agent could recover these credentials.

## Remediation

Added shell command echoing suppression (`set +x` before, `set -x` after) around all invocations that pass passwords on the command line:

**Files modified:**
- `jenkins/venafi-csp-apksigner.groovy`
- `jenkins/venafi-csp-ant-signjar/Jenkinsfile`
- `jenkins/venafi-csp-maven-jarsigner/Jenkinsfile`
- `jenkins/venafi-csp-gradle-ant-signjar/Jenkinsfile`
- `jenkins/venafi-csp-cosign.groovy`
- `gitlab/venafi-csp-apple-codesign.yml`
- `awscodebuild/venafi-csp-cosign-buildspec.yml`
- `argocd/venafi-csp-jarsigner.yml`
- `bitbucket/venafi-csp-jarsigner.yml`
- `bitbucket/venafi-csp-signtool.yml`

**Example change:**
```diff
- pkcs11config getgrant --password=$PASSWORD
+ set +x
+ pkcs11config getgrant --password=$PASSWORD
+ set -x
```

This prevents the password from appearing in shell trace output while still allowing the command to execute normally.

## Verification

- ✅ All 10 vulnerable command invocations updated with command echo suppression
- ✅ No build regressions (repository contains pipeline examples only, no build/test suite)
- ✅ Changes are minimal and focused on the security issue

**Note:** While this fix prevents passwords from appearing in CI logs via shell echo, the arguments are still visible in process listings while the command executes. For production deployments, consider:
1. Configuring CI secret masking for all password variables
2. Using tool-native credential stores or stdin-based password input where supported
3. Ensuring process isolation on shared build agents